### PR TITLE
Fix to set default error code to -1

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -103,7 +103,8 @@ func (js *JobService) Status(ctx context.Context, req *proto.StatusRequest) (res
 
 	s := job.Status()
 	resp = &proto.StatusResponse{
-		Status: s.String(),
+		Status:   s.String(),
+		ExitCode: -1,
 	}
 	if s == core.Running || s == core.Pending {
 		return resp, nil


### PR DESCRIPTION
The default of 0 is confusing if a job hasn't exited.